### PR TITLE
No slot for already distributed

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ meaning it cannot be observed or reflected in shadow root. This result in `slot-
 See issues https://github.com/webcomponents/shadydom/issues/260, https://github.com/webcomponents/shadydom/issues/261, https://github.com/webcomponents/shadydom/issues/262, https://github.com/webcomponents/shadydom/issues/263.
 
 ## NOT observing slots in runtime
-This custom element creates slots when once connected and observes host's children. But it does **not observe other slot elements** in the same tree. Meaning, if you will add or remove some slot elements after `<slot-all>` did its job, the element will not correct the list of its slots. For example
+This custom element creates slots once it's connected and observes host's children. But it does **not observe other slot elements** in the same tree. Meaning, if you add or remove some slot elements after `<slot-all>` did its job, the element will not correct the list of its slots. For example
 ```
 <div slot="foo">Foo</div>
 <div slot="bar">Bar</div>

--- a/README.md
+++ b/README.md
@@ -42,10 +42,23 @@ Or [download as ZIP](https://github.com/Juicy/slot-all/archive/master.zip).
 
 ## Caveats
 
+## Observing slottable elements in polyfilled browsers
 WebComponentsJS Shadow DOM polyfill has some limitations.
 It does ignore `node.remove()` and `.insertAdjacentElement()` calls,
 meaning it cannot be observed or reflected in shadow root. This result in `slot-all` element being unable to react on child nodes been added or removed using these methods. If you are targeting polyfilled environments try using `node.parentNode.removeChild(node)` and `insertBefore`.
 See issues https://github.com/webcomponents/shadydom/issues/260, https://github.com/webcomponents/shadydom/issues/261, https://github.com/webcomponents/shadydom/issues/262, https://github.com/webcomponents/shadydom/issues/263.
+
+## NOT observing slots in runtime
+This custom element creates slots when once connected and observes host's children. But it does **not observe other slot elements** in the same tree. Meaning, if you will add or remove some slot elements after `<slot-all>` did its job, the element will not correct the list of its slots. For example
+```
+<div slot="foo">Foo</div>
+<div slot="bar">Bar</div>
+#shadow root
+    <slot name="foo"></slot>
+    <slot-all><slot-all>
+#/shadow root
+```
+will distribute "Foo" and "Bar", then if you later remove `<slot name="foo"></slot>` by yourself, `Foo` will no longer be distributed.
 
 ## [Contributing and Development](CONTRIBUTING.md)
 

--- a/slot-all.html
+++ b/slot-all.html
@@ -93,11 +93,10 @@
                     if(
                         element.nodeType === Node.ELEMENT_NODE &&
                         element.hasAttribute('slot') &&
-                        !slotsMap.has(name)
-                        // we do create a slot for elements already
-                        // assigned by other `slot(-all)`s
-                        // to handle distribution when others are removed.
-                        // !element.assignedSlot
+                        !slotsMap.has(name) &&
+                        // do not distribute already distributed elements,
+                        // once the other slot is removed this element will not add it
+                        !element.assignedSlot
                     ){
                         const namedSlot = document.createElement('slot');
                         namedSlot.setAttribute('name', name);

--- a/slot-all.html
+++ b/slot-all.html
@@ -45,6 +45,12 @@
             connectedCallback(){
                 // force it to be non-displayed element
                 this.style.display = 'none';
+                
+                // Do nothing if elements is already disconnected
+                // https://github.com/whatwg/html/pull/4127/files#diff-36cd38f49b9afa08222c0dc9ebfe35ebR67065
+                if(!this.isConnected){
+                    return ;
+                }
                 const host = this.getRootNode().host;
                 // Start observing the shadow host for child list changes
                 // workaround https://github.com/webcomponents/shadydom/issues/260

--- a/slot-all.html
+++ b/slot-all.html
@@ -86,6 +86,13 @@
              * @param  {NodeList|HTMLCollection} nodeList list of host's children or document fragments with children
              */
             _createSlots(nodeList){
+                // Ensure shadow dom distribution is completed in polyfilled browsers
+                // window.ShadyDOM && window.ShadyDOM.flush();
+                // Trick Polymer to render this shadow tree to make `assignedSlot` of element accessible.
+                // it's cheaper than the code above, as flushes only this tree
+                // https://github.com/webcomponents/shadydom/issues/295
+                window.ShadyDOM && window.ShadyDOM.inUse && this.assignedSlot;
+
                 const slotAll = this;
                 const slotsMap = slotAll.__createdSlots;
 

--- a/test/spec.html
+++ b/test/spec.html
@@ -13,7 +13,7 @@
         customElements.define('shadow-host', class extends HTMLElement{
             constructor(){
                 super();
-                this.attachShadow({mode: 'open'}).innerHTML = `<div id="scope"><slot-all></slot-all></div>`;
+                this.attachShadow({mode: 'open'}).innerHTML = `<div id="scope"><slot name="used"></slot><slot-all></slot-all></div>`;
             }
         });
         /** workaround for ShadyDOM bug https://github.com/webcomponents/shadydom/issues/255 */
@@ -31,6 +31,7 @@
                 <div slot="name">Div slotted by name</div>
                 <div slot="name">Div2 slotted by name</div>
                 <div slot="name2">Div slotted by name2</div>
+                <div slot="used">Div already slotted by used</div>
                 <div>default</div>
             </shadow-host>
         </template>
@@ -57,7 +58,7 @@
         it('should create `slot` elements for all slot names used by host\'s children, and add `all-slotted` attribute to them', function() {
             expect(querySelectorChildren(host.shadowRoot,`#scope`, `slot[name][all-slotted]`)).to.have.lengthOf(2);
             Array.from(host.children).forEach((child)=>{
-                child.hasAttribute('slot') &&
+                child.hasAttribute('slot') && child.getAttribute("slot") !== "used" &&
                 expect(querySelectorChildren(host.shadowRoot, '#scope', `slot[name="${child.getAttribute('slot')}"][all-slotted]`)).to.have.lengthOf(1);
             });
         });
@@ -164,6 +165,31 @@
                 expect(querySelectorChildren(host.shadowRoot,`#scope`, `slot[name][all-slotted]`)).to.have.lengthOf(2);
                 expect(querySelectorChildren(host.shadowRoot, '#scope', `slot[name="name2"]`)).to.have.lengthOf(1);
                 expect(querySelectorChildren(host.shadowRoot, '#scope', `slot[name="name"]`)).to.have.lengthOf(1);
+            });
+        });
+        describe('when native `slot` is added for an element(s) distributed by `slot-all`', function() {
+            beforeEach(function(done) {
+                const newSlot = document.createElement('slot');
+                newSlot.setAttribute('name','name');
+                host.shadowRoot.appendChild(newSlot);
+                // wait for mutation observer
+                setTimeout(done, 0);
+            });
+
+            it('should not remove already created `slot` for this element(s)', function() {
+                expect(querySelectorChildren(host.shadowRoot, '#scope', `slot[name="name"][all-slotted]`)).to.have.lengthOf(1);
+            });
+        });
+        describe('when native `slot` is removed for an element(s) distributed by `slot-all`', function() {
+            beforeEach(function(done) {
+                const nativeSlot = host.shadowRoot.querySelector('slot[name="used"]');
+                nativeSlot.parentNode.removeChild(nativeSlot);
+                // wait for mutation observer
+                setTimeout(done, 0);
+            });
+
+            it('should NOT add new `slot` for this element(s)', function() {
+                expect(querySelectorChildren(host.shadowRoot, '#scope', `slot[name="used"][all-slotted]`)).to.have.lengthOf(0);
             });
         });
         describe('when `slot-all` element is removed', function() {


### PR DESCRIPTION
- Do not create slots for already distributed elements, Fixes Starcounter/HeadsOmni#683
- Protect against trying to access parent node when disconnected on `connectedCallback`